### PR TITLE
Move synthax highlighting in a common Processor

### DIFF
--- a/src/Decoder/HtmlDecoder.php
+++ b/src/Decoder/HtmlDecoder.php
@@ -8,8 +8,6 @@
 
 namespace Content\Decoder;
 
-use Content\Behaviour\HighlighterInterface;
-use Content\Service\HtmlUtils;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 
@@ -24,16 +22,6 @@ class HtmlDecoder implements DecoderInterface
     public const FORMAT = 'html';
 
     /**
-     * Code highlighter
-     */
-    protected HighlighterInterface $highlighter;
-
-    public function __construct(HighlighterInterface $highlighter)
-    {
-        $this->highlighter = $highlighter;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function decode($data, $format, array $context = [])
@@ -44,16 +32,6 @@ class HtmlDecoder implements DecoderInterface
 
         $crawler->filterXPath('//head/meta')->each(function ($node) use (&$attributes): void {
             $attributes[$node->attr('name')] = $node->attr('content');
-        });
-
-        $crawler->filter('code')->each(function (Crawler $node): void {
-            if ($language = $node->attr('highlight')) {
-                $element = $node->getNode(0);
-                HtmlUtils::setContent($element, $this->highlighter->highlight(trim($node->html()), $language));
-
-                $element->removeAttribute('highlight');
-                HtmlUtils::addClass($element, $language);
-            }
         });
 
         return array_merge(

--- a/src/Processor/CodeHighlightProcessor.php
+++ b/src/Processor/CodeHighlightProcessor.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the "Tom32i/Content" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Content\Processor;
+
+use Content\Behaviour\HighlighterInterface;
+use Content\Behaviour\ProcessorInterface;
+use Content\Content;
+use Content\Service\HtmlUtils;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Apply synthax coloration to code blocs
+ */
+class CodeHighlightProcessor implements ProcessorInterface
+{
+    private HighlighterInterface $highlighter;
+    private string $property;
+
+    public function __construct(HighlighterInterface $highlighter, string $property = 'content')
+    {
+        $this->highlighter = $highlighter;
+        $this->property = $property;
+    }
+
+    public function __invoke(array &$data, string $type, Content $content): void
+    {
+        if (!isset($data[$this->property])) {
+            return;
+        }
+
+        $crawler = new Crawler($data[$this->property]);
+
+        try {
+            $crawler->html();
+        } catch (\Exception $e) {
+            // Content is not valid HTML.
+            return;
+        }
+
+        $crawler = new Crawler($data[$this->property]);
+
+        foreach ($crawler->filter('code') as $element) {
+            $this->highlight($element);
+        }
+
+        $data[$this->property] = $crawler->html();
+    }
+
+    /**
+     * Set title id and add anchor
+     */
+    private function highlight(\DOMElement $element): void
+    {
+        if ($language = $element->getAttribute('highlight')) {
+            HtmlUtils::setContent($element, $this->highlighter->highlight(trim($element->nodeValue), $language));
+            HtmlUtils::addClass($element, implode(' ', ['highlight', $language]));
+            $element->removeAttribute('highlight');
+        }
+    }
+}

--- a/src/Processor/CodeHighlightProcessor.php
+++ b/src/Processor/CodeHighlightProcessor.php
@@ -52,9 +52,6 @@ class CodeHighlightProcessor implements ProcessorInterface
         $data[$this->property] = $crawler->html();
     }
 
-    /**
-     * Set title id and add anchor
-     */
     private function highlight(\DOMElement $element): void
     {
         if ($language = $element->getAttribute('highlight')) {

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -14,8 +14,6 @@ services:
         tags: [serializer.encoder]
 
     Content\Decoder\HtmlDecoder:
-        arguments:
-            $highlighter: '@Content\Highlighter\Prism'
         tags: [serializer.encoder]
 
     Content\EventListener\Informator:
@@ -38,13 +36,17 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.terminate, method: stop }
 
-    Content\Service\Parsedown:
-        $highlighter: '@Content\Highlighter\Prism'
+    Content\Service\Parsedown: ~
 
     Content\Processor\LastModifiedProcessor:
         tags: ['content.processor']
 
     Content\Processor\SlugProcessor:
+        tags: ['content.processor']
+
+    Content\Processor\CodeHighlightProcessor:
+        arguments:
+            $highlighter: '@Content\Highlighter\Prism'
         tags: ['content.processor']
 
     Content\Processor\HtmlIdProcessor:


### PR DESCRIPTION
La coloration syntaxique est appliqué comme un post-processor à tout les blocs `<code highlight="xxx">` dans le contenu.

Avantages : 
- Décorrélé des décodeurs (le même code s'applique que le contenu ai été produit depuis un fichier markdown ou html).
- L'utilisateur peu changer de décodeur Markdown ou créer des décodeur custom : il bénéficiera quand même de la coloration syntaxique.
- Facilement désactivable.
- Gère automatiquement les cas à la marge (comme un bloque code inséré directement en HTML dans un fichier markdown).