### PR TITLE
Allow processors to hydrate objects

### DIFF
--- a/src/ContentManager.php
+++ b/src/ContentManager.php
@@ -11,6 +11,7 @@ namespace Content;
 use Content\Behaviour\ContentManagerAwareInterface;
 use Content\Behaviour\ProcessorInterface;
 use Content\Provider\ContentProviderInterface;
+use Content\Serializer\Normalizer\SkippingInstantiatedObjectDenormalizer;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
@@ -146,7 +147,9 @@ class ContentManager
             $processor($data, $type, $content);
         }
 
-        $data = $this->denormalizer->denormalize($data, $type, $content->getFormat());
+        $data = $this->denormalizer->denormalize($data, $type, $content->getFormat(), [
+            SkippingInstantiatedObjectDenormalizer::SKIP => true,
+        ]);
 
         return $this->cache[$key] = $data;
     }

--- a/src/Processor/CodeHighlightProcessor.php
+++ b/src/Processor/CodeHighlightProcessor.php
@@ -15,7 +15,7 @@ use Content\Service\HtmlUtils;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
- * Apply synthax coloration to code blocs
+ * Apply syntax coloration to code blocs
  */
 class CodeHighlightProcessor implements ProcessorInterface
 {

--- a/src/Processor/LastModifiedProcessor.php
+++ b/src/Processor/LastModifiedProcessor.php
@@ -30,6 +30,6 @@ class LastModifiedProcessor implements ProcessorInterface
             return;
         }
 
-        $data[$this->property] = $content->getLastModified() ? $content->getLastModified()->format(\DateTimeInterface::RFC3339) : null;
+        $data[$this->property] = $content->getLastModified();
     }
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -29,6 +29,7 @@ use Content\Processor\SlugProcessor;
 use Content\Provider\Factory\ContentProviderFactory;
 use Content\Provider\Factory\LocalFilesystemProviderFactory;
 use Content\Routing\UrlGenerator;
+use Content\Serializer\Normalizer\SkippingInstantiatedObjectDenormalizer;
 use Content\Service\Parsedown;
 use Content\Twig\ContentExtension;
 use Content\Twig\ContentRuntime;
@@ -94,6 +95,9 @@ return static function (ContainerConfigurator $container): void {
             '$executable' => null,
             '$stopwatch' => service('debug.stopwatch')->nullOnInvalid(),
         ])->tag('kernel.event_listener', ['event' => KernelEvents::TERMINATE, 'method' => 'stop'])
+
+        // Serializer
+        ->set(SkippingInstantiatedObjectDenormalizer::class)->tag('serializer.normalizer')
 
         // Decoders
         ->set(MarkdownDecoder::class)

--- a/src/Serializer/Normalizer/SkippingInstantiatedObjectDenormalizer.php
+++ b/src/Serializer/Normalizer/SkippingInstantiatedObjectDenormalizer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the "Tom32i/Content" bundle.
+ *
+ * @author Thomas Jarrand <thomas.jarrand@gmail.com>
+ */
+
+namespace Content\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+
+/**
+ * Avoiding double-denormalization for already instantiated objects inside $data.
+ */
+class SkippingInstantiatedObjectDenormalizer implements ContextAwareDenormalizerInterface
+{
+    public const SKIP = 'skip_instantiated_object';
+
+    public function denormalize($data, string $type, string $format = null, array $context = [])
+    {
+        return $data;
+    }
+
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    {
+        return (bool) ($context[self::SKIP] ?? false) && \is_object($data);
+    }
+}


### PR DESCRIPTION
Ex without:

```
In DateTimeNormalizer.php line 101:

  DateTimeImmutable::__construct() expects parameter 1 to be string, object given
```

Due to the `LastModifiedProcessor` returning an already instantiated `\DateTime` object.

This adds more flexibility to the processors.