### PR TITLE
Provide a filter option for getContents + allow multiple sort keys

### DIFF
--- a/doc/loading-content.md
+++ b/doc/loading-content.md
@@ -122,15 +122,66 @@ class BlogController extends AbstractController
 
 ### Sorting contents
 
-The `getContents` method have a second parameters `$sortBy` that allow sorting the content list.
+The `getContents` method have a second parameters `$sortBy` that allows sorting the content list.
 
-This argument accepts:
+It accepts:
 
-- An string: `'lastModified'` (sort by ascending values of the "lastModified" property).
-- An array: `['title' => false]` (sort by descending values of the "title" property).
-- A comparison callable for the PHP [usort](https://www.php.net/manual/fr/function.usort.php) function: `fn($a, $b) => $a->priority <=> $b->priority`.
+#### A property name (string)
 
-When provided, the ContentManager will list all contents and sort the array with the corresponding sorting function before returning it.
+Alphabetically sorted categories:
+
+```php
+$categories = $contentManager->getContents(Category::class, 'title');
+```
+
+#### An array of properties and sorting mode
+
+All articles sorted by descending `date` (most recent first) and then by ascending `title` (Alphabetically):
+
+```php
+$latestArticles = $contentManager->getContents(Category::class, ['date' => false, 'title' => true]);
+```
+
+#### A custom callable supported by the PHP [usort](https://www.php.net/manual/fr/function.usort.php) function
+
+```php
+$tasks = $contentManager->getContents(Task::class, fn($a, $b) => $a->priority <=> $b->priority);
+```
+
+### Filtering contents
+
+The `getContents` method have a third parameters `$filterBy` that allows filtering the content list.
+
+It accepts:
+
+#### An array of properties and values
+
+```php
+$articles = $contentManager->getContents(Article::class, null, ['category' => 'symfony']);
+```
+
+When passing multiple requirements, all must be met:
+
+```php
+$myDrafts = $this->manager->getContents(Article::class, null, ['author' => 'ogizanagi', 'draft' => true]);
+```
+
+#### A property name (string)
+
+```php
+// Equivalent to ['active' => true]
+$users = $contentManager->getContents(User::class, 'active');
+```
+
+#### A custom callable supported by the PHP [usort](https://www.php.net/manual/fr/function.usort.php) function
+
+```php
+$tagedMobileArticles = $this->manager->getContents(
+    Article::class,
+    null,
+    fn (Article $article): bool => in_array('mobile', $article->tags)
+);
+```
 
 ## Advanced usage and extension
 

--- a/src/ContentManager.php
+++ b/src/ContentManager.php
@@ -35,6 +35,8 @@ class ContentManager
     /** @var array<string,object> */
     private array $cache = [];
 
+    private bool $managerInjected = false;
+
     public function __construct(
         DecoderInterface $decoder,
         DenormalizerInterface $denormalizer,
@@ -259,15 +261,14 @@ class ContentManager
 
     private function initProcessors(): void
     {
-        static $managerInjected = false;
         // Lazy inject manager to processor on first need:
-        if (!$managerInjected) {
+        if (!$this->managerInjected) {
             foreach ($this->processors as $processor) {
                 if ($processor instanceof ContentManagerAwareInterface) {
                     $processor->setContentManager($this);
                 }
             }
-            $managerInjected = true;
+            $this->managerInjected = true;
         }
     }
 }

--- a/src/Twig/ContentRuntime.php
+++ b/src/Twig/ContentRuntime.php
@@ -28,8 +28,8 @@ class ContentRuntime implements RuntimeExtensionInterface
     /**
      * @return object[]
      */
-    public function listContents(string $type, $sortBy): array
+    public function listContents(string $type, $sortBy, $filterBy): array
     {
-        return $this->contentManager->getContents($type, $sortBy);
+        return $this->contentManager->getContents($type, $sortBy, $filterBy);
     }
 }

--- a/src/Twig/ContentRuntime.php
+++ b/src/Twig/ContentRuntime.php
@@ -28,7 +28,7 @@ class ContentRuntime implements RuntimeExtensionInterface
     /**
      * @return object[]
      */
-    public function listContents(string $type, $sortBy, $filterBy): array
+    public function listContents(string $type, $sortBy = null, $filterBy = null): array
     {
         return $this->contentManager->getContents($type, $sortBy, $filterBy);
     }

--- a/tests/Unit/ContentManagerTest.php
+++ b/tests/Unit/ContentManagerTest.php
@@ -98,8 +98,18 @@ class ContentManagerTest extends TestCase
         ], array_column($manager->getContents('App\Foo', ['order' => false]), 'content'), 'desc order');
 
         self::assertSame([
+            'Foo 2',
             'Foo 1',
-        ], array_column($manager->getContents('App\Foo', [], ['content' => 'Foo 1']), 'content'), 'filtered');
+            'Foo 3',
+        ], array_column($manager->getContents('App\Foo', fn ($a, $b) => $a->order <=> $b->order), 'content'), 'ordered by function');
+
+        self::assertSame([
+            'Foo 1',
+        ], array_column($manager->getContents('App\Foo', null, ['content' => 'Foo 1']), 'content'), 'filtered by key');
+
+        self::assertSame([
+            'Foo 2',
+        ], array_column($manager->getContents('App\Foo', null, fn ($foo) => $foo->content === 'Foo 2'), 'content'), 'filtered by function');
     }
 }
 

--- a/tests/Unit/ContentManagerTest.php
+++ b/tests/Unit/ContentManagerTest.php
@@ -67,7 +67,7 @@ class ContentManagerTest extends TestCase
 
         $orders = [2, 1, 3];
         $denormalizer
-            ->denormalize(Argument::type('array'), 'App\Foo', Argument::any())
+            ->denormalize(Argument::type('array'), 'App\Foo', Argument::any(), Argument::any())
             ->will(function ($args) use (&$orders) {
                 [$data] = $args;
                 $std = new \stdClass();
@@ -79,7 +79,6 @@ class ContentManagerTest extends TestCase
             })
             ->shouldBeCalledTimes(3)
         ;
-
         self::assertSame([
             'Foo 1',
             'Foo 2',
@@ -97,6 +96,10 @@ class ContentManagerTest extends TestCase
             'Foo 1',
             'Foo 2',
         ], array_column($manager->getContents('App\Foo', ['order' => false]), 'content'), 'desc order');
+
+        self::assertSame([
+            'Foo 1',
+        ], array_column($manager->getContents('App\Foo', [], ['content' => 'Foo 1']), 'content'), 'filtered');
     }
 }
 


### PR DESCRIPTION
- [x] Filter option
- [x] Multi  sort option
- [x] Tests
- [x] Documentation

--- 

## Exemple d'usage

### Filtrer sur une propriété : 

```php
$activeUsers = $this->manager->getContents(User::class, null, 'active');
```

### Filtrer sur la valeur propriété : 

```php
$articles = $this->manager->getContents(Article::class, null, ['category' => 'Infra']);
```

### Filtrer sur plusieurs propriétés : 

```php
$myDrafts = $this->manager->getContents(Article::class, null, ['author' => 'ogi', 'draft' => true]);
```

Le sorting bénéficie aussi de cet amélioration : 

```php
// Sort by author and then by date:
$articles = $this->manager->getContents(Article::class, ['author' => true, 'date' => false]);
```

### Filtre custom (callable) : 

```php
$articlesAboutMobile = $this->manager->getContents(
    Article::class,
    null,
    fn (Article $article): bool => in_array('mobile', $article->tags)
);
```