### PR TITLE
Rely on String component for anchor slugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "symfony/property-access": "^5.1",
         "symfony/routing": "^5.1",
         "symfony/serializer": "^5.1",
+        "symfony/string": "^5.1",
         "symfony/yaml": "^5.1",
         "twig/twig": "^2.12|^3.0"
     },

--- a/src/Processor/HtmlIdProcessor.php
+++ b/src/Processor/HtmlIdProcessor.php
@@ -11,6 +11,8 @@ namespace Content\Processor;
 use Content\Behaviour\ProcessorInterface;
 use Content\Content;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 /**
  * Add ids to title in the content
@@ -18,10 +20,12 @@ use Symfony\Component\DomCrawler\Crawler;
 class HtmlIdProcessor implements ProcessorInterface
 {
     private string $property;
+    private SluggerInterface $slugger;
 
-    public function __construct(string $property = 'content')
+    public function __construct(string $property = 'content', ?SluggerInterface $slugger = null)
     {
         $this->property = $property;
+        $this->slugger = $slugger ?? new AsciiSlugger();
     }
 
     public function __invoke(array &$data, string $type, Content $content): void
@@ -81,7 +85,7 @@ class HtmlIdProcessor implements ProcessorInterface
      */
     private function slugify(string $value, int $maxLength = 32): string
     {
-        return trim(preg_replace('#[^a-z0-9]+#i', '-', strtolower(substr($value, 0, $maxLength))), '-');
+        return $this->slugger->slug($value)->truncate($maxLength, '', false)->lower();
     }
 
     /**

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -42,6 +42,7 @@ use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 require_once __DIR__ . '/tags.php';
 
@@ -147,7 +148,10 @@ return static function (ContainerConfigurator $container): void {
     $container->services()->defaults()->tag(tags\content_processor)
         ->set(LastModifiedProcessor::class)
         ->set(SlugProcessor::class)
-        ->set(HtmlIdProcessor::class)
+        ->set(HtmlIdProcessor::class)->args([
+            '$property' => 'content',
+            '$slugger' => service(SluggerInterface::class),
+        ])
         ->set(HtmlAnchorProcessor::class)
         ->set(HtmlExternalLinksProcessor::class)
         ->set(ExtractTitleFromHtmlContentProcessor::class)


### PR DESCRIPTION
See https://symfony.com/doc/current/components/string.html

The component is already shipped in most installs, as it's a transitive dependency of console & property-info. So let's rely on its shoulders.
It supports transliteration and locale specific transformations.